### PR TITLE
Enable M-series (NAX / Metal 4) attention & GEMM kernels without raising the deployment target

### DIFF
--- a/.ci_support/linux_64_python3.10.____cpython.yaml
+++ b/.ci_support/linux_64_python3.10.____cpython.yaml
@@ -15,7 +15,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '14'
 docker_image:
-- quay.io/condaforge/linux-anvil-x86_64:alma9
+- quay.io/condaforge/linux-anvil-x86_64:alma10
 libblas:
 - 3.9.* *netlib
 libcblas:

--- a/.ci_support/linux_64_python3.11.____cpython.yaml
+++ b/.ci_support/linux_64_python3.11.____cpython.yaml
@@ -15,7 +15,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '14'
 docker_image:
-- quay.io/condaforge/linux-anvil-x86_64:alma9
+- quay.io/condaforge/linux-anvil-x86_64:alma10
 libblas:
 - 3.9.* *netlib
 libcblas:

--- a/.ci_support/linux_64_python3.12.____cpython.yaml
+++ b/.ci_support/linux_64_python3.12.____cpython.yaml
@@ -15,7 +15,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '14'
 docker_image:
-- quay.io/condaforge/linux-anvil-x86_64:alma9
+- quay.io/condaforge/linux-anvil-x86_64:alma10
 libblas:
 - 3.9.* *netlib
 libcblas:

--- a/.ci_support/linux_64_python3.13.____cp313.yaml
+++ b/.ci_support/linux_64_python3.13.____cp313.yaml
@@ -15,7 +15,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '14'
 docker_image:
-- quay.io/condaforge/linux-anvil-x86_64:alma9
+- quay.io/condaforge/linux-anvil-x86_64:alma10
 libblas:
 - 3.9.* *netlib
 libcblas:

--- a/.ci_support/linux_64_python3.14.____cp314.yaml
+++ b/.ci_support/linux_64_python3.14.____cp314.yaml
@@ -15,7 +15,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '14'
 docker_image:
-- quay.io/condaforge/linux-anvil-x86_64:alma9
+- quay.io/condaforge/linux-anvil-x86_64:alma10
 libblas:
 - 3.9.* *netlib
 libcblas:

--- a/.ci_support/linux_aarch64_python3.10.____cpython.yaml
+++ b/.ci_support/linux_aarch64_python3.10.____cpython.yaml
@@ -15,7 +15,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '14'
 docker_image:
-- quay.io/condaforge/linux-anvil-aarch64:alma9
+- quay.io/condaforge/linux-anvil-aarch64:alma10
 libblas:
 - 3.9.* *netlib
 libcblas:

--- a/.ci_support/linux_aarch64_python3.11.____cpython.yaml
+++ b/.ci_support/linux_aarch64_python3.11.____cpython.yaml
@@ -15,7 +15,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '14'
 docker_image:
-- quay.io/condaforge/linux-anvil-aarch64:alma9
+- quay.io/condaforge/linux-anvil-aarch64:alma10
 libblas:
 - 3.9.* *netlib
 libcblas:

--- a/.ci_support/linux_aarch64_python3.12.____cpython.yaml
+++ b/.ci_support/linux_aarch64_python3.12.____cpython.yaml
@@ -15,7 +15,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '14'
 docker_image:
-- quay.io/condaforge/linux-anvil-aarch64:alma9
+- quay.io/condaforge/linux-anvil-aarch64:alma10
 libblas:
 - 3.9.* *netlib
 libcblas:

--- a/.ci_support/linux_aarch64_python3.13.____cp313.yaml
+++ b/.ci_support/linux_aarch64_python3.13.____cp313.yaml
@@ -15,7 +15,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '14'
 docker_image:
-- quay.io/condaforge/linux-anvil-aarch64:alma9
+- quay.io/condaforge/linux-anvil-aarch64:alma10
 libblas:
 - 3.9.* *netlib
 libcblas:

--- a/.ci_support/linux_aarch64_python3.14.____cp314.yaml
+++ b/.ci_support/linux_aarch64_python3.14.____cp314.yaml
@@ -15,7 +15,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '14'
 docker_image:
-- quay.io/condaforge/linux-anvil-aarch64:alma9
+- quay.io/condaforge/linux-anvil-aarch64:alma10
 libblas:
 - 3.9.* *netlib
 libcblas:

--- a/.ci_support/osx_arm64_python3.10.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.10.____cpython.yaml
@@ -1,7 +1,7 @@
 MACOSX_DEPLOYMENT_TARGET:
 - '14.5'
 MACOSX_SDK_VERSION:
-- '14.5'
+- '26.0'
 c_compiler:
 - clang
 c_compiler_version:

--- a/.ci_support/osx_arm64_python3.11.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.11.____cpython.yaml
@@ -1,7 +1,7 @@
 MACOSX_DEPLOYMENT_TARGET:
 - '14.5'
 MACOSX_SDK_VERSION:
-- '14.5'
+- '26.0'
 c_compiler:
 - clang
 c_compiler_version:

--- a/.ci_support/osx_arm64_python3.12.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.12.____cpython.yaml
@@ -1,7 +1,7 @@
 MACOSX_DEPLOYMENT_TARGET:
 - '14.5'
 MACOSX_SDK_VERSION:
-- '14.5'
+- '26.0'
 c_compiler:
 - clang
 c_compiler_version:

--- a/.ci_support/osx_arm64_python3.13.____cp313.yaml
+++ b/.ci_support/osx_arm64_python3.13.____cp313.yaml
@@ -1,7 +1,7 @@
 MACOSX_DEPLOYMENT_TARGET:
 - '14.5'
 MACOSX_SDK_VERSION:
-- '14.5'
+- '26.0'
 c_compiler:
 - clang
 c_compiler_version:

--- a/.ci_support/osx_arm64_python3.14.____cp314.yaml
+++ b/.ci_support/osx_arm64_python3.14.____cp314.yaml
@@ -1,7 +1,7 @@
 MACOSX_DEPLOYMENT_TARGET:
 - '14.5'
 MACOSX_SDK_VERSION:
-- '14.5'
+- '26.0'
 c_compiler:
 - clang
 c_compiler_version:

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         include:
           - CONFIG: linux_64_python3.10.____cpython
-            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma10
             STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             build_workspace_dir: build_artifacts
@@ -35,7 +35,7 @@ jobs:
             runs_on: ['ubuntu-latest']
             tools_install_dir: ~/miniforge3
           - CONFIG: linux_64_python3.11.____cpython
-            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma10
             STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             build_workspace_dir: build_artifacts
@@ -47,7 +47,7 @@ jobs:
             runs_on: ['ubuntu-latest']
             tools_install_dir: ~/miniforge3
           - CONFIG: linux_64_python3.12.____cpython
-            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma10
             STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             build_workspace_dir: build_artifacts
@@ -59,7 +59,7 @@ jobs:
             runs_on: ['ubuntu-latest']
             tools_install_dir: ~/miniforge3
           - CONFIG: linux_64_python3.13.____cp313
-            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma10
             STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             build_workspace_dir: build_artifacts
@@ -71,7 +71,7 @@ jobs:
             runs_on: ['ubuntu-latest']
             tools_install_dir: ~/miniforge3
           - CONFIG: linux_64_python3.14.____cp314
-            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma10
             STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             build_workspace_dir: build_artifacts
@@ -83,7 +83,7 @@ jobs:
             runs_on: ['ubuntu-latest']
             tools_install_dir: ~/miniforge3
           - CONFIG: linux_aarch64_python3.10.____cpython
-            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-aarch64:alma9
+            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-aarch64:alma10
             STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             build_workspace_dir: build_artifacts
@@ -95,7 +95,7 @@ jobs:
             runs_on: ['ubuntu-24.04-arm']
             tools_install_dir: ~/miniforge3
           - CONFIG: linux_aarch64_python3.11.____cpython
-            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-aarch64:alma9
+            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-aarch64:alma10
             STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             build_workspace_dir: build_artifacts
@@ -107,7 +107,7 @@ jobs:
             runs_on: ['ubuntu-24.04-arm']
             tools_install_dir: ~/miniforge3
           - CONFIG: linux_aarch64_python3.12.____cpython
-            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-aarch64:alma9
+            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-aarch64:alma10
             STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             build_workspace_dir: build_artifacts
@@ -119,7 +119,7 @@ jobs:
             runs_on: ['ubuntu-24.04-arm']
             tools_install_dir: ~/miniforge3
           - CONFIG: linux_aarch64_python3.13.____cp313
-            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-aarch64:alma9
+            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-aarch64:alma10
             STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             build_workspace_dir: build_artifacts
@@ -131,7 +131,7 @@ jobs:
             runs_on: ['ubuntu-24.04-arm']
             tools_install_dir: ~/miniforge3
           - CONFIG: linux_aarch64_python3.14.____cp314
-            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-aarch64:alma9
+            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-aarch64:alma10
             STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             build_workspace_dir: build_artifacts

--- a/recipe/0002-Build-M-series-NAX-Metal-kernels-without-raising-the-.patch
+++ b/recipe/0002-Build-M-series-NAX-Metal-kernels-without-raising-the-.patch
@@ -1,0 +1,215 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: conda-forge <noreply@conda-forge.org>
+Date: Mon, 3 Aug 2026 09:00:00 +0000
+Subject: [PATCH] Ship M-series NAX (Metal 4) kernels without raising the
+ deployment target
+
+The NAX kernels (steel_attention_nax, steel_gemm_*_nax, quantized_nax) use
+MetalPerformancePrimitives cooperative-tensor matmul (mpp::tensor_ops) and must
+be compiled for macOS 26.2 / Metal 4.0 (AIR >= 2.8). They give a large
+attention/SDPA and GEMM speedup on capable M-series GPUs.
+
+Upstream only builds them when the whole library targets macOS >= 26.2
+(MLX_METAL_VERSION >= 400 AND MACOS_SDK_VERSION >= 26.2 AND
+CMAKE_OSX_DEPLOYMENT_TARGET >= 26.2), because air-lld cannot embed Metal 4
+(AIR 2.8) functions into the base mlx.metallib when it is linked for an older
+deployment target -- it drops them with a warning. Forcing the deployment
+target up would drop every user on an older macOS.
+
+Instead, compile the NAX kernels into a SEPARATE mlx_nax.metallib linked for
+macOS 26.2, next to mlx.metallib. It is loaded on demand via
+get_library("mlx_nax") from the NAX kernel getters, which MLX only ever calls
+when is_nax_available() is true at runtime. is_nax_available()
+(mlx/backend/metal/device.cpp) guards with __builtin_available(macOS 26.2, *)
+plus a GPU-generation check, so an older-macOS host never dispatches a NAX
+kernel and never loads the second metallib -- it runs exactly as before, while
+capable macOS 26.2+ M-series GPUs get the faster kernels.
+
+The base mlx.metallib and the library's MACOSX_DEPLOYMENT_TARGET are unchanged.
+---
+diff --git a/mlx/backend/metal/kernels/CMakeLists.txt b/mlx/backend/metal/kernels/CMakeLists.txt
+index edc169e..25e3093 100644
+--- a/mlx/backend/metal/kernels/CMakeLists.txt
++++ b/mlx/backend/metal/kernels/CMakeLists.txt
+@@ -155,22 +155,60 @@ if(NOT MLX_METAL_JIT)
+   build_kernel(gemv_masked steel/utils.h)
+   build_kernel(steel/attn/kernels/steel_attention ${STEEL_ATTN_HEADERS})
+ 
+-  if(MLX_METAL_VERSION GREATER_EQUAL 400
+-     AND MACOS_SDK_VERSION VERSION_GREATER_EQUAL 26.2
+-     AND CMAKE_OSX_DEPLOYMENT_TARGET VERSION_GREATER_EQUAL 26.2)
++  # The M-series NAX kernels use MetalPerformancePrimitives cooperative-tensor
++  # matmul (mpp::tensor_ops) and must be compiled for macOS 26.2 / Metal 4.0
++  # (AIR >= 2.8). air-lld refuses to embed those functions into the base
++  # mlx.metallib when it is linked for an older deployment target, so instead of
++  # forcing the whole library up to macOS 26.2 we compile the NAX kernels into a
++  # SEPARATE mlx_nax.metallib linked for 26.2. The library deployment target is
++  # left untouched, and MLX only ever loads/creates the NAX pipelines when
++  # is_nax_available() is true at runtime -- see mlx/backend/metal/device.cpp,
++  # which additionally guards with __builtin_available(macOS 26.2, *) -- so an
++  # older-macOS build keeps running exactly as before and never touches the
++  # second metallib there.
++  if(NOT DEFINED MLX_NAX_DEPLOYMENT_TARGET)
++    set(MLX_NAX_DEPLOYMENT_TARGET "26.2")
++  endif()
++  if(MACOS_SDK_VERSION VERSION_GREATER_EQUAL 26.2)
++    function(build_nax_kernel KERNEL)
++      set(SRCFILE ${CMAKE_CURRENT_SOURCE_DIR}/${KERNEL}.metal)
++      cmake_path(GET KERNEL STEM TARGET)
++      set(METAL_FLAGS
++          -x
++          metal
++          -Wall
++          -Wextra
++          -fno-fast-math
++          -Wno-c++17-extensions
++          -Wno-c++20-extensions
++          "-mmacosx-version-min=${MLX_NAX_DEPLOYMENT_TARGET}")
++      add_custom_command(
++        COMMAND xcrun -sdk macosx metal ${METAL_FLAGS} -c ${SRCFILE}
++                -I${PROJECT_SOURCE_DIR} -o ${TARGET}.air
++        DEPENDS ${SRCFILE} ${ARGN} ${BASE_HEADERS}
++        OUTPUT ${TARGET}.air
++        COMMENT "Building ${TARGET}.air (NAX, macOS ${MLX_NAX_DEPLOYMENT_TARGET})"
++        VERBATIM)
++      set(NAX_KERNEL_AIR
++          ${TARGET}.air ${NAX_KERNEL_AIR}
++          PARENT_SCOPE)
++    endfunction()
+ 
+-    build_kernel(steel/gemm/kernels/steel_gemm_fused_nax ${STEEL_NAX_HEADERS})
+-    build_kernel(steel/gemm/kernels/steel_gemm_gather_nax ${STEEL_NAX_HEADERS})
+-    build_kernel(steel/gemm/kernels/steel_gemm_splitk_nax ${STEEL_NAX_HEADERS})
+-    build_kernel(steel/gemm/kernels/steel_gemm_segmented_nax
+-                 ${STEEL_NAX_HEADERS})
++    build_nax_kernel(steel/gemm/kernels/steel_gemm_fused_nax
++                     ${STEEL_NAX_HEADERS})
++    build_nax_kernel(steel/gemm/kernels/steel_gemm_gather_nax
++                     ${STEEL_NAX_HEADERS})
++    build_nax_kernel(steel/gemm/kernels/steel_gemm_splitk_nax
++                     ${STEEL_NAX_HEADERS})
++    build_nax_kernel(steel/gemm/kernels/steel_gemm_segmented_nax
++                     ${STEEL_NAX_HEADERS})
+ 
+-    build_kernel(quantized_nax quantized_nax.h ${STEEL_NAX_HEADERS})
+-    build_kernel(fp_quantized_nax fp4.h fp8.h fp_quantized_nax.h
+-                 ${STEEL_NAX_HEADERS})
++    build_nax_kernel(quantized_nax quantized_nax.h ${STEEL_NAX_HEADERS})
++    build_nax_kernel(fp_quantized_nax fp4.h fp8.h fp_quantized_nax.h
++                     ${STEEL_NAX_HEADERS})
+ 
+-    build_kernel(steel/attn/kernels/steel_attention_nax
+-                 ${STEEL_NAX_ATTN_HEADERS})
++    build_nax_kernel(steel/attn/kernels/steel_attention_nax
++                     ${STEEL_NAX_ATTN_HEADERS})
+ 
+   else()
+     target_compile_definitions(mlx PRIVATE MLX_METAL_NO_NAX)
+@@ -195,6 +233,23 @@ add_custom_target(mlx-metallib DEPENDS ${MLX_METAL_PATH}/mlx.metallib)
+ 
+ add_dependencies(mlx mlx-metallib)
+ 
++# Separate metallib for the NAX (Metal 4.0) kernels, linked for macOS 26.2 so
++# that the base mlx.metallib can keep a lower deployment target. It sits next to
++# mlx.metallib and is loaded on demand via get_library("mlx_nax") only when
++# is_nax_available() is true at runtime.
++if(NAX_KERNEL_AIR)
++  set(NAX_METAL_LINK_FLAGS "-mmacosx-version-min=${MLX_NAX_DEPLOYMENT_TARGET}")
++  add_custom_command(
++    OUTPUT ${MLX_METAL_PATH}/mlx_nax.metallib
++    COMMAND xcrun -sdk macosx metal ${NAX_METAL_LINK_FLAGS} ${NAX_KERNEL_AIR} -o
++            ${MLX_METAL_PATH}/mlx_nax.metallib
++    DEPENDS ${NAX_KERNEL_AIR}
++    COMMENT "Building mlx_nax.metallib"
++    VERBATIM)
++  add_custom_target(mlx-nax-metallib DEPENDS ${MLX_METAL_PATH}/mlx_nax.metallib)
++  add_dependencies(mlx mlx-nax-metallib)
++endif()
++
+ # Install metallib
+ include(GNUInstallDirs)
+ 
+@@ -202,3 +257,10 @@ install(
+   FILES ${MLX_METAL_PATH}/mlx.metallib
+   DESTINATION ${CMAKE_INSTALL_LIBDIR}
+   COMPONENT metallib)
++
++if(NAX_KERNEL_AIR)
++  install(
++    FILES ${MLX_METAL_PATH}/mlx_nax.metallib
++    DESTINATION ${CMAKE_INSTALL_LIBDIR}
++    COMPONENT metallib)
++endif()
+diff --git a/mlx/backend/metal/nojit_kernels.cpp b/mlx/backend/metal/nojit_kernels.cpp
+index 64cfa39..70a9532 100644
+--- a/mlx/backend/metal/nojit_kernels.cpp
++++ b/mlx/backend/metal/nojit_kernels.cpp
+@@ -362,7 +362,8 @@ MTL::ComputePipelineState* get_steel_gemm_fused_nax_kernel(
+     int,
+     int,
+     int) {
+-  return d.get_kernel(kernel_name, hash_name, func_consts);
++  return d.get_kernel(
++      kernel_name, d.get_library("mlx_nax"), hash_name, func_consts);
+ }
+ 
+ MTL::ComputePipelineState* get_steel_gemm_gather_nax_kernel(
+@@ -379,7 +380,8 @@ MTL::ComputePipelineState* get_steel_gemm_gather_nax_kernel(
+     int,
+     int,
+     bool) {
+-  return d.get_kernel(kernel_name, hash_name, func_consts);
++  return d.get_kernel(
++      kernel_name, d.get_library("mlx_nax"), hash_name, func_consts);
+ }
+ 
+ MTL::ComputePipelineState* get_steel_gemm_splitk_nax_kernel(
+@@ -395,7 +397,8 @@ MTL::ComputePipelineState* get_steel_gemm_splitk_nax_kernel(
+     int,
+     int,
+     int) {
+-  return d.get_kernel(kernel_name, hash_name, func_consts);
++  return d.get_kernel(
++      kernel_name, d.get_library("mlx_nax"), hash_name, func_consts);
+ }
+ 
+ MTL::ComputePipelineState* get_steel_gemm_segmented_nax_kernel(
+@@ -411,7 +414,8 @@ MTL::ComputePipelineState* get_steel_gemm_segmented_nax_kernel(
+     int,
+     int,
+     int) {
+-  return d.get_kernel(kernel_name, hash_name, func_consts);
++  return d.get_kernel(
++      kernel_name, d.get_library("mlx_nax"), hash_name, func_consts);
+ }
+ 
+ MTL::ComputePipelineState* get_qmm_nax_kernel(
+@@ -419,7 +423,7 @@ MTL::ComputePipelineState* get_qmm_nax_kernel(
+     const std::string& kernel_name,
+     const std::string&,
+     const std::string&) {
+-  return d.get_kernel(kernel_name);
++  return d.get_kernel(kernel_name, d.get_library("mlx_nax"));
+ }
+ 
+ MTL::ComputePipelineState* get_gather_qmm_nax_kernel(
+@@ -437,7 +441,8 @@ MTL::ComputePipelineState* get_gather_qmm_nax_kernel(
+     int,
+     int,
+     bool) {
+-  return d.get_kernel(kernel_name, hash_name, func_consts);
++  return d.get_kernel(
++      kernel_name, d.get_library("mlx_nax"), hash_name, func_consts);
+ }
+ 
+ MTL::ComputePipelineState* get_steel_attention_kernel(
+@@ -467,7 +472,8 @@ MTL::ComputePipelineState* get_steel_attention_nax_kernel(
+     int,
+     int,
+     const array&) {
+-  return d.get_kernel(kernel_name, hash_name, func_consts);
++  return d.get_kernel(
++      kernel_name, d.get_library("mlx_nax"), hash_name, func_consts);
+ }
+ 
+ } // namespace mlx::core

--- a/recipe/check_nax_metallib.py
+++ b/recipe/check_nax_metallib.py
@@ -1,0 +1,39 @@
+# Verifies the separate NAX (Metal 4) shader library, mlx_nax.metallib, shipped
+# by recipe/0002-*.patch. This whole mechanism -- the patch, this test, and the
+# extra metallib -- can be removed once MACOSX_DEPLOYMENT_TARGET is raised past
+# 26.2, because upstream then builds the NAX kernels straight into mlx.metallib.
+import glob
+import os
+import sys
+
+libdir = os.path.join(sys.prefix, "lib")
+base = os.path.join(libdir, "mlx.metallib")
+nax = os.path.join(libdir, "mlx_nax.metallib")
+
+# The base Metal shader library must always ship next to libmlx.dylib.
+found = glob.glob(os.path.join(sys.prefix, "**", "mlx.metallib"), recursive=True)
+assert os.path.isfile(base), f"mlx.metallib not at {base}; found instead: {found}"
+
+# The NAX metallib is built only when the build toolchain provides a macOS >=
+# 26.2 Metal SDK (see the gate in recipe/0002-*.patch). When it is built it MUST
+# be shipped right next to mlx.metallib -- the runtime loads it from there via
+# get_library("mlx_nax") -- and be non-empty. Its absence on an older-SDK build
+# is expected (the NAX kernels are compiled out and never dispatched).
+if os.path.isfile(nax):
+    assert os.path.getsize(nax) > 0, f"{nax} is empty"
+    print(f"OK: mlx_nax.metallib shipped ({os.path.getsize(nax)} bytes) next to mlx.metallib")
+else:
+    stray = glob.glob(os.path.join(sys.prefix, "**", "mlx_nax.metallib"), recursive=True)
+    assert not stray, f"mlx_nax.metallib built but not installed next to mlx.metallib: {stray}"
+    print("OK: mlx_nax.metallib not built (build Metal SDK < 26.2) -- NAX compiled out, as expected")
+
+# Exercise the attention path end to end. On a NAX-capable GPU + build this
+# dispatches the NAX kernel and loads mlx_nax.metallib; were that library built
+# but not packaged, this would raise "Failed to load the metallib mlx_nax.metallib".
+import mlx.core as mx  # noqa: E402
+
+q = mx.random.normal((1, 8, 256, 64))
+out = mx.fast.scaled_dot_product_attention(q, q, q, scale=64 ** -0.5)
+mx.eval(out)
+assert out.shape == (1, 8, 256, 64)
+print("OK: scaled_dot_product_attention ran on", mx.default_device())

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,7 +1,12 @@
 # Keep the deployment target (c_stdlib_version / MACOSX_DEPLOYMENT_TARGET)
-# unchanged so the package keeps running on older macOS, but build against the
-# macOS 26 SDK so the Metal toolchain can compile the newer M-series
-# (MetalPerformancePrimitives) kernels. See recipe/0002-*.patch.
+# unchanged so the package keeps running on older macOS. Build against the
+# newest macOS SDK conda-forge-ci-setup currently ships (26.0). The NAX
+# (MetalPerformancePrimitives) kernels want a >= 26.2 C++ sysroot, but 26.2 is
+# not yet packaged in conda-forge-ci-setup's download_osx_sdk.sh (bumping it
+# there fails the SDK download), so 26.0 is the ceiling for now. This is not the
+# limiting factor: the NAX gate is ultimately driven by the Metal 4 / Xcode
+# >= 26.2 toolchain, which MLX reads from `xcrun --show-sdk-version`
+# independently of this C++ sysroot pin. See recipe/0002-*.patch.
 c_stdlib_version:          # [osx and arm64]
   - "14.5"                 # [osx and arm64]
 MACOSX_SDK_VERSION:        # [osx and arm64]

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,4 +1,8 @@
+# Keep the deployment target (c_stdlib_version / MACOSX_DEPLOYMENT_TARGET)
+# unchanged so the package keeps running on older macOS, but build against the
+# macOS 26 SDK so the Metal toolchain can compile the newer M-series
+# (MetalPerformancePrimitives) kernels. See recipe/0002-*.patch.
 c_stdlib_version:          # [osx and arm64]
   - "14.5"                 # [osx and arm64]
 MACOSX_SDK_VERSION:        # [osx and arm64]
-  - "14.5"                 # [osx and arm64]
+  - "26.0"                 # [osx and arm64]

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -14,9 +14,12 @@ source:
   sha256: 8e74a0eb613861ce50c09402dd99dbc42b65a762e7fdd291caa39f611db978ec
   patches:
     - 0001-Omit-visionOS-from-sources.patch
+    # Build the M-series NAX (MetalPerformancePrimitives) kernels without
+    # raising the library deployment target. See the patch header for details.
+    - 0002-Build-M-series-NAX-Metal-kernels-without-raising-the-.patch
 
 build:
-  number: 0
+  number: 1
   skip: win or match(python, "<3.9") or (osx and x86_64)
 
 requirements:

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -63,6 +63,15 @@ tests:
       - pip check
       - if: osx and arm64
         then: python -m unittest discover python/tests
+  # mlx_nax.metallib (the separate Metal 4 / NAX shader library added by
+  # recipe/0002-*.patch) -- along with this test and that patch -- can be dropped
+  # once MACOSX_DEPLOYMENT_TARGET is raised past 26.2.
+  - script:
+      - if: osx and arm64
+        then: python check_nax_metallib.py
+    files:
+      recipe:
+        - check_nax_metallib.py
 
 about:
   summary: An array framework for Apple silicon


### PR DESCRIPTION
Hey all,

Thanks for taking the time to review this. I wanted to add support for newer M5 chips without raising the runtime. Let me know what you think of this. It's been tested locally, and I'm excited to see more support for MLX.

<details><summary>Technical details (Claude's notes)</summary>

## Summary

On Apple **M5 / M-series GPUs**, MLX has a much faster attention/SDPA and GEMM path built on the **NAX kernels** — the `steel_attention_nax` / `steel_gemm_*_nax` / `quantized_nax` kernels that use Metal's `MetalPerformancePrimitives` cooperative-tensor matmul (`mpp::tensor_ops`, Metal 4.0). The conda-forge package currently ships **without** these kernels, so `mlx.core.fast.scaled_dot_product_attention` falls back to the classic simdgroup path and runs several times slower than Apple's own pip wheel of the same MLX version.

## Why the NAX kernels are missing

MLX gates their compilation (`mlx/backend/metal/kernels/CMakeLists.txt`) on:

```cmake
if(MLX_METAL_VERSION GREATER_EQUAL 400
   AND MACOS_SDK_VERSION VERSION_GREATER_EQUAL 26.2
   AND CMAKE_OSX_DEPLOYMENT_TARGET VERSION_GREATER_EQUAL 26.2)
```

`MLX_METAL_VERSION` is itself derived from `metal -mmacosx-version-min=${CMAKE_OSX_DEPLOYMENT_TARGET}`, so upstream only builds them when the **whole library** targets macOS ≥ 26.2. `air-lld` cannot embed the Metal 4 (AIR ≥ 2.8) functions into the base `mlx.metallib` when it is linked for an older deployment target — it drops them with a warning. Enabling them the upstream way would mean raising `MACOSX_DEPLOYMENT_TARGET` from `14.5` to `26.2` and dropping every user on an older macOS.

## What this PR does

Compiles the NAX kernels into a **separate `mlx_nax.metallib`** linked for macOS 26.2, sitting next to `mlx.metallib`. It is loaded on demand via `get_library("mlx_nax")` from the NAX kernel getters, which MLX only ever calls when `is_nax_available()` is true at runtime — and `is_nax_available()` (`mlx/backend/metal/device.cpp`) additionally guards with `__builtin_available(macOS 26.2, *)` plus a GPU-generation check. So an older-macOS host never dispatches a NAX kernel and never loads the second metallib; capable macOS 26.2+ M-series GPUs get the faster kernels.

- **`MACOSX_DEPLOYMENT_TARGET` / `c_stdlib_version` stay at `14.5`** — no older-macOS users are dropped (`run` dep is `__osx >=14.5`).
- The base `mlx.metallib` is unchanged; the NAX kernels live only in the separate metallib.
- `MACOSX_SDK_VERSION` (C++ sysroot) is bumped to **26.0** — the newest SDK conda-forge-ci-setup currently ships. (26.2 is not packaged there yet; requesting it fails the SDK download.) This is **not** the limiting factor: whether the NAX kernels compile is driven by the **Metal toolchain** version, which MLX reads from `xcrun --show-sdk-version`, independent of this C++ sysroot pin.
- Build number bumped `0 → 1`.

## Behavior on the current CI image

The macOS builds here run on an image whose Metal toolchain is macOS SDK ~15.5, so `MACOS_SDK_VERSION >= 26.2` is false and the NAX kernels are **compiled out** — `MLX_METAL_NO_NAX` is defined, `is_nax_available()` returns `false`, and only `mlx.metallib` is produced. On today's runners this patch is therefore a **safe no-op**: the package is functionally identical to the current one. It will emit the faster kernels once a macOS 26.2+ / Metal 4 (Xcode ≥ 26.2) toolchain is available on CI.

## Tested locally

Built the feedstock on an **M5 Max / macOS 26.5 / Xcode 26.5** toolchain:
- The build compiled `steel_attention_nax.air` (macOS 26.2) and shipped `lib/mlx_nax.metallib` (24 NAX symbols) next to `lib/mlx.metallib` (0), with `__osx >=14.5` unchanged.
- Installed the resulting `.conda` into a fresh env: `mx.fast.scaled_dot_product_attention` on a 16k-token attention runs in **~23 ms vs ~68 ms** for the classic path — matching Apple's pip `mlx-metal` wheel — and MLX loads `mlx_nax.metallib` from `$PREFIX/lib` (co-located with `libmlx.dylib`).

## Test added

`recipe/check_nax_metallib.py` (osx + arm64) asserts `mlx.metallib` always ships, asserts `mlx_nax.metallib` is present and non-empty **when the build produced it** (and not built-but-unshipped), then runs a real `scaled_dot_product_attention` so that on a NAX-capable GPU the metallib load path itself is exercised. On a NAX-compiled-out build it passes via the classic path. (Note: conda-forge's osx build runs `--test=skip`, so this runs on local builds / `conda test` rather than on the build CI here.)

The separate `mlx_nax.metallib`, this test, and this patch can all be removed once `MACOSX_DEPLOYMENT_TARGET` is raised past 26.2 (upstream then builds the NAX kernels straight into `mlx.metallib`).

## Feedback welcome

In particular, confirmation of the mixed-`-mmacosx-version-min` approach — that the resulting `mlx.metallib` (linked 14.5) plus `mlx_nax.metallib` (linked 26.2) still loads on the minimum supported macOS while exposing the NAX functions on capable GPUs.

</details>
